### PR TITLE
Update VideoEncoderNVENC.cpp

### DIFF
--- a/alvr/server/cpp/platform/win32/VideoEncoderNVENC.cpp
+++ b/alvr/server/cpp/platform/win32/VideoEncoderNVENC.cpp
@@ -109,7 +109,7 @@ void VideoEncoderNVENC::Transmit(ID3D11Texture2D *pTexture, uint64_t presentatio
 	const NvEncInputFrame* encoderInputFrame = m_NvNecoder->GetNextInputFrame();
 	ID3D11Texture2D *pInputTexture = reinterpret_cast<ID3D11Texture2D*>(encoderInputFrame->inputPtr);
 
-//SHN ScreenGrab1.0  已启用
+//SHN ScreenGrab1.0  已启用 或许要考虑只抓取几帧关键帧来确定时间戳
    // 如果 开启截图按钮 才进行Copy纹理信息
 	if (/*true*/ /*false*/Settings::Instance().m_captureLayerDDSTrigger)		//Settings::Instance().m_captureLayerDDSTrigger  Settings::Instance().m_DebugCaptureOutput
 	{


### PR DESCRIPTION
准备弃用 ScreenGrab 来获取原始视频帧，文件的读写太过于占用线程资源，在不开启抓取时的总时延在50ms-60ms 开启后高达500ms以上，即使将ScreenGrab  的调用写在另一个线程里 其花费的时间也是很多的，总时延还是会更大